### PR TITLE
Fixed speaker order in case of frequently used setups + other fixes

### DIFF
--- a/Source/Driver/ASIO2WASAPI.h
+++ b/Source/Driver/ASIO2WASAPI.h
@@ -146,8 +146,8 @@ private:
     //for default device changed notification
     CMMNotificationClient* pNotificationClient;
     
-    static DWORD WINAPI PlayThreadProc(LPVOID pThis);
-    static DWORD WINAPI PlayThreadProcShared(LPVOID pThis);
+    static void PlayThreadProc(LPVOID pThis);
+    static void PlayThreadProcShared(LPVOID pThis);
     static BOOL CALLBACK ControlPanelProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam);    
     static void initInputFields(IMMDevice* pDevice, ASIO2WASAPI* pDriver, const HWND hwndDlg);
     

--- a/Source/Driver/dllmain.cpp
+++ b/Source/Driver/dllmain.cpp
@@ -84,7 +84,10 @@ BOOL WINAPI DllMain(
 	
 		case DLL_PROCESS_ATTACH:
 			g_hinstDLL = hinstDLL;
-            DisableThreadLibraryCalls(hinstDLL);
+#ifndef _MT
+            DisableThreadLibraryCalls(hinstDLL); //Do not call this in case of static crt
+#endif           
+
 			hinstance = hinstDLL;
 			InitClasses(TRUE);
 			


### PR DESCRIPTION
1. Fixed speaker order in case of some frequently used speaker setups.
2. Fixed rendering threads handle leaks.
3. Added proper latency report in case of shared mode.
4. Latencies somewhat improved in both shared and exclusive modes.