### PR TITLE
latency shared mode period + buggy hosts control panel workaround

### DIFF
--- a/Source/Driver/ASIO2WASAPI.cpp
+++ b/Source/Driver/ASIO2WASAPI.cpp
@@ -379,7 +379,7 @@ IAudioClient* getAudioClient(IMMDevice* pDevice, WAVEFORMATEX* pWaveFormat, int&
         hr = pAudioClient3->GetCurrentSharedModeEnginePeriod(&format, &currentPeriod);
         hr = pAudioClient3->GetSharedModeEnginePeriod(format, &defaultPeriod, &fundamentalPeriod, &minPeriod, &maxPeriod);
         if (FAILED(hr)) return NULL;
-        while (minPeriod < (defaultPeriod / 2)) minPeriod += fundamentalPeriod; //aim is about 5ms update period, 240 samples at 48kHz in ASIO terms 
+        while (minPeriod < (UINT32)(defaultPeriod * 0.4)) minPeriod += fundamentalPeriod; //4 ms update period seems to be a good compromise between latency and stability
         hr = pAudioClient3->InitializeSharedAudioStream(AUDCLNT_STREAMFLAGS_EVENTCALLBACK, minPeriod, format, NULL);
         if (hr == AUDCLNT_E_ENGINE_PERIODICITY_LOCKED)
             hr = pAudioClient3->InitializeSharedAudioStream(AUDCLNT_STREAMFLAGS_EVENTCALLBACK, currentPeriod, format, NULL);

--- a/Source/Driver/ASIO2WASAPI.cpp
+++ b/Source/Driver/ASIO2WASAPI.cpp
@@ -1600,7 +1600,10 @@ ASIOError ASIO2WASAPI::getChannels (long *numInputChannels, long *numOutputChann
 ASIOError ASIO2WASAPI::controlPanel()
 {   
     if (m_hControlPanelHandle) DestroyWindow(m_hControlPanelHandle);
-    DialogBoxParam(g_hinstDLL,MAKEINTRESOURCE(IDD_CONTROL_PANEL),m_hAppWindowHandle,(DLGPROC)ControlPanelProc,(LPARAM)this);
+        
+    HWND parentWindow = m_hAppWindowHandle ? m_hAppWindowHandle : GetActiveWindow();   
+    DialogBoxParam(g_hinstDLL, MAKEINTRESOURCE(IDD_CONTROL_PANEL), parentWindow, (DLGPROC)ControlPanelProc, (LPARAM)this);
+
     return ASE_OK;
 }
 
@@ -1626,6 +1629,7 @@ ASIOBool ASIO2WASAPI::init(void* sysRef)
 		return true;
 
     m_hAppWindowHandle = (HWND) sysRef;
+    m_hControlPanelHandle = 0;
     pNotificationClient = NULL;
 
     HRESULT hr=S_OK;

--- a/Source/Driver/version.h
+++ b/Source/Driver/version.h
@@ -1,8 +1,8 @@
 #pragma once
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 2
-#define VERSION_PATCH 1
-#define VERSION_BUILD 2
+#define VERSION_PATCH 2
+#define VERSION_BUILD 1
 
 #define stringify(a) stringify_(a)
 #define stringify_(a) #a


### PR DESCRIPTION
1. Finally made low latency shared mode period derived from buffer size.
2. Workaround for hosts that do not set dialog's parent window correctly. 